### PR TITLE
Switch to use pre-commit

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+    ignore = E203, E266, E501, W503, F403, F401
+    max-line-length = 120

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         pip freeze
 
     - name: lint
-      run: make lint
+      run: pre-commit run --all-files
 
     - name: mypy
       run: make mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,24 @@
+files: 'arq/.*|tests/.*'
+repos:
+  - repo: https://github.com/psf/black
+    rev: 19.10b0
+    hooks:
+      - id: black
+        language_version: python3.7
+
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.9
+    hooks:
+      - id: flake8
+        language: python
+
+  - repo: https://github.com/pycqa/isort
+    rev: 4.3.21
+    hooks:
+      - id: isort
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.790
+    hooks:
+      - id: mypy
+        files: 'arq/.*'

--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,10 @@
 .DEFAULT_GOAL := all
-isort = isort -rc arq tests
-black = black -S -l 120 --target-version py37 arq tests
 
 .PHONY: install
 install:
 	pip install -U pip setuptools
 	pip install -r requirements.txt
 	pip install -e .[watch]
-
-.PHONY: format
-format:
-	$(isort)
-	$(black)
-
-.PHONY: lint
-lint:
-	flake8 arq/ tests/
-	$(isort) --check-only -df
-	$(black) --check
 
 .PHONY: test
 test:

--- a/arq/worker.py
+++ b/arq/worker.py
@@ -11,10 +11,9 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Sequence,
 
 import async_timeout
 from aioredis import MultiExecError
-from pydantic.utils import import_string
-
 from arq.cron import CronJob
 from arq.jobs import Deserializer, JobResult, SerializationError, Serializer, deserialize_job_raw, serialize_result
+from pydantic.utils import import_string
 
 from .connections import ArqRedis, RedisSettings, create_pool, log_redis_info
 from .constants import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.black]
+line-length = 120
+target-version = ['py37']
+skip-string-normalization = true

--- a/setup.py
+++ b/setup.py
@@ -1,68 +1,65 @@
-from pathlib import Path
-
 from importlib.machinery import SourceFileLoader
+from pathlib import Path
 from setuptools import setup
 
-description = 'Job queues in python with asyncio and redis'
-readme = Path(__file__).parent / 'README.md'
+description = "Job queues in python with asyncio and redis"
+readme = Path(__file__).parent / "README.md"
 if readme.exists():
     long_description = readme.read_text()
 else:
-    long_description = description + '.\n\nSee https://arq-docs.helpmanual.io/ for documentation.'
+    long_description = description + ".\n\nSee https://arq-docs.helpmanual.io/ for documentation."
 # avoid loading the package before requirements are installed:
-version = SourceFileLoader('version', 'arq/version.py').load_module()
+version = SourceFileLoader("version", "arq/version.py").load_module()
 
 setup(
-    name='arq',
+    name="arq",
     version=version.VERSION,
     description=description,
     long_description=long_description,
-    long_description_content_type='text/markdown',
+    long_description_content_type="text/markdown",
     classifiers=[
-        'Development Status :: 4 - Beta',
-        'Environment :: Console',
-        'Framework :: AsyncIO',
-        'Intended Audience :: Developers',
-        'Intended Audience :: Information Technology',
-        'Intended Audience :: System Administrators',
-        'License :: OSI Approved :: MIT License',
-        'Operating System :: Unix',
-        'Operating System :: POSIX :: Linux',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-        'Topic :: Internet',
-        'Topic :: Software Development :: Libraries :: Python Modules',
-        'Topic :: System :: Clustering',
-        'Topic :: System :: Distributed Computing',
-        'Topic :: System :: Monitoring',
-        'Topic :: System :: Systems Administration',
+        "Development Status :: 4 - Beta",
+        "Environment :: Console",
+        "Framework :: AsyncIO",
+        "Intended Audience :: Developers",
+        "Intended Audience :: Information Technology",
+        "Intended Audience :: System Administrators",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: Unix",
+        "Operating System :: POSIX :: Linux",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Topic :: Internet",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+        "Topic :: System :: Clustering",
+        "Topic :: System :: Distributed Computing",
+        "Topic :: System :: Monitoring",
+        "Topic :: System :: Systems Administration",
     ],
-    python_requires='>=3.6',
-    author='Samuel Colvin',
-    author_email='s@muelcolvin.com',
-    url='https://github.com/samuelcolvin/arq',
-    license='MIT',
-    packages=['arq'],
-    package_data={'arq': ['py.typed']},
+    python_requires=">=3.6",
+    author="Samuel Colvin",
+    author_email="s@muelcolvin.com",
+    url="https://github.com/samuelcolvin/arq",
+    license="MIT",
+    packages=["arq"],
+    package_data={"arq": ["py.typed"]},
     zip_safe=True,
     entry_points="""
         [console_scripts]
         arq=arq.cli:cli
     """,
     install_requires=[
-        'async-timeout>=3.0.0',
-        'aioredis>=1.1.0',
-        'click>=6.7',
-        'pydantic>=1',
+        "async-timeout>=3.0.0",
+        "aioredis>=1.1.0",
+        "click>=6.7",
+        "pydantic>=1",
         'dataclasses>=0.6;python_version == "3.6"',
-        'typing-extensions>=3.7;python_version < "3.8"'
+        'typing-extensions>=3.7;python_version < "3.8"',
     ],
-    extras_require={
-        'watch': ['watchgod>=0.4'],
-    }
+    extras_require={"watch": ["watchgod>=0.4"],},
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,6 @@ import functools
 import msgpack
 import pytest
 from aioredis import create_redis_pool
-
 from arq.connections import ArqRedis, create_pool
 from arq.worker import Worker
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,5 @@
-from click.testing import CliRunner
-
 from arq.cli import cli
+from click.testing import CliRunner
 
 
 async def foobar(ctx):

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -4,7 +4,6 @@ from datetime import datetime, timedelta
 from random import random
 
 import pytest
-
 from arq import Worker
 from arq.cron import cron, next_cron
 

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -2,12 +2,11 @@ import asyncio
 import pickle
 
 import pytest
-from pytest_toolbox.comparison import CloseToNow
-
 from arq import Worker, func
 from arq.connections import ArqRedis, RedisSettings, create_pool
 from arq.constants import default_queue_name, in_progress_key_prefix, job_key_prefix, result_key_prefix
 from arq.jobs import DeserializationError, Job, JobResult, JobStatus, deserialize_job_raw, serialize_result
+from pytest_toolbox.comparison import CloseToNow
 
 
 async def test_job_in_progress(arq_redis: ArqRedis):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -7,13 +7,12 @@ from random import shuffle
 from time import time
 
 import pytest
-from pytest_toolbox.comparison import AnyInt, CloseToNow
-
 from arq.connections import ArqRedis
 from arq.constants import default_queue_name
 from arq.jobs import Job, JobDef, SerializationError
 from arq.utils import timestamp_ms
 from arq.worker import Retry, Worker, func
+from pytest_toolbox.comparison import AnyInt, CloseToNow
 
 
 async def test_enqueue_job(arq_redis: ArqRedis, worker):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,12 +2,11 @@ import logging
 import re
 from datetime import timedelta
 
-import pytest
-from pydantic import BaseModel, validator
-
 import arq.typing
 import arq.utils
+import pytest
 from arq.connections import RedisSettings, log_redis_info
+from pydantic import BaseModel, validator
 
 
 def test_settings_changed():

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -9,7 +9,6 @@ from unittest.mock import MagicMock
 import msgpack
 import pytest
 from aioredis import create_redis_pool
-
 from arq.connections import ArqRedis
 from arq.constants import default_queue_name, health_check_key_suffix, job_key_prefix
 from arq.jobs import Job, JobStatus


### PR DESCRIPTION
Integrates precommit into CI builds as well.  Removes linting from makefile to prevent confusion.

Should note that I couldn't get the formatting to work exactly identical to the make file for some reason, particularly isort.  There are some files that are slightly changed with import order as a result.